### PR TITLE
Unify Accept-Language header construction

### DIFF
--- a/src/commonMain/kotlin/com/metrolist/innertubex/InnerTube.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/InnerTube.kt
@@ -337,12 +337,6 @@ class InnerTube(
 
     private fun sanitizeAuthUser(value: String): String = value.filter { it.isDigit() }.ifBlank { "0" }
 
-    private fun YouTubeLocale.acceptLanguageHeader(): String {
-        val languageTag = hl.replace('_', '-')
-        val regionalTag = if ('-' in languageTag) languageTag else "$languageTag-$gl"
-        return "$regionalTag,${languageTag.substringBefore('-')};q=0.9"
-    }
-
     private fun resolveSapisidValue(cookie: String?): String? {
         val cookieMap = cookie?.let(::parseCookieString).orEmpty()
         return cookieMap["SAPISID"]

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
@@ -1244,7 +1244,7 @@ class InnerTubeExtractor internal constructor(
         if (clientName != "ANDROID_VR" && clientName != "VISIONOS" && clientName != "TVHTML5_SIMPLY") {
             headers["User-Agent"] = userAgent
             headers["Accept"] = "*/*"
-            headers["Accept-Language"] = "${innerTube.locale.hl}-${innerTube.locale.gl},${innerTube.locale.hl};q=0.9"
+            headers["Accept-Language"] = innerTube.locale.acceptLanguageHeader()
 
             when (clientName) {
                 "WEB_REMIX" -> {

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/YtConfigParserImpl.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/YtConfigParserImpl.kt
@@ -72,7 +72,7 @@ public class YtConfigParserImpl(
                 header(HttpHeaders.Accept, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
                 referer?.let { header("Referer", it) }
                 requestCookie?.let { header(HttpHeaders.Cookie, it) }
-                header(HttpHeaders.AcceptLanguage, "${innerTube.locale.hl}-${innerTube.locale.gl},${innerTube.locale.hl};q=0.9")
+                header(HttpHeaders.AcceptLanguage, innerTube.locale.acceptLanguageHeader())
                 timeout {
                     requestTimeoutMillis = PAGE_TIMEOUT_MS
                     connectTimeoutMillis = PAGE_TIMEOUT_MS

--- a/src/commonMain/kotlin/com/metrolist/innertubex/models/YouTubeLocale.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/models/YouTubeLocale.kt
@@ -6,4 +6,11 @@ import kotlinx.serialization.Serializable
 data class YouTubeLocale(
     val gl: String,
     val hl: String,
-)
+) {
+    internal fun acceptLanguageHeader(): String {
+        val languageTag = hl.replace('_', '-')
+        val regionalTag = if ('-' in languageTag || gl.isEmpty()) languageTag else "$languageTag-$gl"
+        val fallback = languageTag.substringBefore('-')
+        return if (regionalTag == fallback) regionalTag else "$regionalTag,$fallback;q=0.9"
+    }
+}

--- a/src/commonTest/kotlin/com/metrolist/innertubex/InnerTubeSessionTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/InnerTubeSessionTest.kt
@@ -750,6 +750,17 @@ class InnerTubeSessionTest {
         }
 
     @Test
+    fun requestLanguageHeaderOmitsRegionWhenCountryIsEmpty() =
+        runBlocking {
+            val engine = MockEngine { respondOk() }
+            val innerTube = clientWithContentNegotiation(engine).also { it.locale = YouTubeLocale(gl = "", hl = "en") }
+
+            innerTube.browse(YouTubeClient.WEB_REMIX, browseId = "FEmusic_home")
+
+            assertEquals("en", engine.requestHistory.single().headers[HttpHeaders.AcceptLanguage])
+        }
+
+    @Test
     fun searchSendsVisitorData() =
         runBlocking {
             val engine = MockEngine { respondOk() }


### PR DESCRIPTION
InnerTubeExtractor and YtConfigParserImpl were manually constructing the Accept-Language header with `hl-gl`, which duplicated the region tag when hl already contained one (e.g. `it-IT-IT`). YouTube would ignore the malformed header and fall back to English.

This moves acceptLanguageHeader() into YouTubeLocale so all call sites use the same correct logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved localization handling for network requests by generating standardized `Accept-Language` values.
  * Added regional language tags with base-language fallbacks for more consistent language negotiation.
  * Applied the improved locale handling across configuration, extraction, authentication, and visitor-data requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->