### PR TITLE
Reduce playback startup latency and refresh failed configurations

### DIFF
--- a/api/desktop/innertubex.api
+++ b/api/desktop/innertubex.api
@@ -218,6 +218,7 @@ public final class com/metrolist/innertubex/cipher/YouTubeCipherService {
 	public final fun processNParameter (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun refreshAfterStreamRejection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun refreshForUnknownPlayer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setPreprocessedPlayerCache (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/metrolist/innertubex/extraction/AudioQuality : java/lang/Enum {

--- a/src/commonMain/kotlin/com/metrolist/innertubex/cipher/EjsChallengeSolver.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/cipher/EjsChallengeSolver.kt
@@ -2,6 +2,7 @@ package com.metrolist.innertubex.cipher
 
 import com.metrolist.innertubex.InnerTubeLogger
 import com.metrolist.innertubex.d
+import com.metrolist.innertubex.utils.sha1
 import com.metrolist.innertubex.w
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
@@ -10,6 +11,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
@@ -18,6 +20,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlin.time.Clock
+
+private val PREPROCESSED_CACHE_KEY_REGEX = Regex("[a-f0-9]{40}")
 
 /**
  * Runs yt-dlp's embedded JS solver (EJS) inside QuickJS — needed when the player uses
@@ -50,13 +54,24 @@ internal class EjsChallengeSolver(
 
     private val initMutex = Mutex()
     private var bootstrapped = false
+    private var bundleHash: String? = null
 
     private val preprocessedMutex = Mutex()
     private val preprocessedByPlayerUrl = LinkedHashMap<String, String>()
+    private var readPreprocessedPlayer: suspend (String) -> String? = { null }
+    private var writePreprocessedPlayer: suspend (String, String?) -> Unit = { _, _ -> }
 
     /** Ensures EJS lib/core are evaluated once (safe to call before loading parser _solve* scripts). */
     suspend fun ensureLoaded() {
         ensureBootstrapped()
+    }
+
+    fun setPreprocessedPlayerCache(
+        read: suspend (String) -> String?,
+        write: suspend (String, String?) -> Unit,
+    ) {
+        readPreprocessedPlayer = read
+        writePreprocessedPlayer = write
     }
 
     suspend fun cachePreprocessedPlayer(
@@ -77,6 +92,7 @@ internal class EjsChallengeSolver(
             engine.setupYoutubeGlobals()
             val lib = readYtEjsSolverScript("yt.solver.lib.min.js")
             val core = readYtEjsSolverScript("yt.solver.core.min.js")
+            bundleHash = sha1(lib + core)
             engine.execute(lib)
             engine.execute("Object.assign(globalThis, lib);")
             engine.execute(core)
@@ -108,119 +124,203 @@ internal class EjsChallengeSolver(
 
         return try {
             ensureBootstrapped()
+            val cacheKey = bundleHash?.let { preprocessedPlayerCacheKey(playerUrl, it) }
             val preprocessed =
                 if (preferPreprocessed) {
-                    preprocessedMutex.withLock {
-                        preprocessedByPlayerUrl.remove(playerUrl)?.also { preprocessedByPlayerUrl[playerUrl] = it }
-                    }
+                    loadPreprocessedPlayer(playerUrl, cacheKey)
                 } else {
                     null
                 }
 
-            val payload =
-                buildJsonObject {
-                    if (preprocessed != null) {
-                        put("type", "preprocessed")
-                        put("preprocessed_player", preprocessed)
-                    } else {
-                        put("type", "player")
-                        put("player", fullPlayerJs)
-                        put("output_preprocessed", true)
+            if (preprocessed != null) {
+                val cachedResult =
+                    try {
+                        solveOnce(playerUrl, preprocessed, requestOrder, preprocessed = true)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        SolveResult(emptyMap(), emptyMap(), null)
                     }
-                    putJsonArray("requests") {
-                        for ((kind, challenges) in requestOrder) {
-                            if (challenges.isEmpty()) continue
-                            add(
-                                buildJsonObject {
-                                    put("type", kind)
-                                    putJsonArray("challenges") {
-                                        for (c in challenges) {
-                                            add(JsonPrimitive(c))
-                                        }
-                                    }
-                                },
-                            )
-                        }
-                    }
-                }
+                if (cachedResult.solvesAll(requestOrder)) return cachedResult
+                evictPreprocessedPlayer(playerUrl, cacheKey)
+                if (fullPlayerJs.isBlank()) return cachedResult
+            }
 
-            val jsonText = payloadJson.encodeToString(JsonElement.serializer(), payload)
-            if (jsonText.length > MAX_PAYLOAD_LENGTH) return SolveResult(emptyMap(), emptyMap(), null)
-            val payloadLit = QuickJsEngine.jsStringLiteral(jsonText)
-            // jsc() may return objects QuickJS JSON.stringify cannot handle (circular refs);
-            // copy only plain string fields into a new tree before stringify.
-            val js =
-                """
-                (function() {
-                  var payload = JSON.parse($payloadLit);
-                  var r = jsc(payload);
-                  if (!r) return JSON.stringify({"type":"error","error":"jsc returned null"});
-                  if (r.type === "error")
-                    return JSON.stringify({"type":"error","error":String(r.error != null ? r.error : "")});
-                  if (r.type !== "result")
-                    return JSON.stringify({"type":"error","error":"unexpected jsc type: "+String(r.type)});
-                  var out = {"type":"result","responses":[]};
-                  if (typeof r.preprocessed_player === "string" && r.preprocessed_player.length > 0) {
-                    if (r.preprocessed_player.length > $MAX_PLAYER_JS_LENGTH)
-                      return JSON.stringify({"type":"error","error":"preprocessed player too large"});
-                    out.preprocessed_player = r.preprocessed_player;
-                  }
-                  var resps = r.responses;
-                  if (!resps) return JSON.stringify(out);
-                  for (var i = 0; i < resps.length; i++) {
-                    var resp = resps[i];
-                    if (!resp) {
-                      out.responses.push({"type":"error","error":"null response"});
-                      continue;
-                    }
-                    if (resp.type === "error") {
-                      out.responses.push({
-                        "type":"error",
-                        "error":String(resp.error != null ? resp.error : "")
-                      });
-                    } else if (resp.type === "result") {
-                      var d = resp.data;
-                      var plain = {};
-                      if (d && typeof d === "object") {
-                        var keys = Object.keys(d);
-                        for (var j = 0; j < keys.length; j++) {
-                          var k = keys[j];
-                          var v = d[k];
-                          var text = v == null ? "" : String(v);
-                          if (text.length > $MAX_SOLVER_OUTPUT_LENGTH) {
-                            plain = null;
-                            break;
-                          }
-                          plain[k] = text;
-                        }
-                      }
-                      if (plain == null)
-                        out.responses.push({"type":"error","error":"solver output too large"});
-                      else
-                        out.responses.push({"type":"result","data":plain});
-                    } else {
-                      out.responses.push({"type":"error","error":"unknown response type"});
-                    }
-                  }
-                  return JSON.stringify(out);
-                })()
-                """.trimIndent()
-            val evaluateStartMs = Clock.System.now().toEpochMilliseconds()
-            val evaluated = engine.evaluate(js, MAX_RAW_OUTPUT_LENGTH)
-            if (evaluated.length > MAX_RAW_OUTPUT_LENGTH) return SolveResult(emptyMap(), emptyMap(), null)
-            val raw = evaluated.trim()
-            logger.d(
-                TAG,
-                "EJS evaluate done preprocessed=${preprocessed != null} requests=${requestOrder.sumOf {
-                    it.second.size
-                }} elapsed=${Clock.System.now().toEpochMilliseconds() - evaluateStartMs}ms player=${playerUrl.logId()}",
-            )
-            parseOutput(playerUrl, raw, requestOrder)
+            solveOnce(playerUrl, fullPlayerJs, requestOrder, preprocessed = false).also { result ->
+                result.preprocessedPlayer?.let { persistPreprocessedPlayer(cacheKey, it) }
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             logger.w(TAG, "EJS solve failed player=${playerUrl.logId()} type=${e.logType()}")
             SolveResult(emptyMap(), emptyMap(), null)
+        }
+    }
+
+    private suspend fun solveOnce(
+        playerUrl: String,
+        playerInputText: String,
+        requestOrder: List<Pair<String, List<String>>>,
+        preprocessed: Boolean,
+    ): SolveResult {
+        val requests =
+            buildJsonArray {
+                for ((kind, challenges) in requestOrder) {
+                    if (challenges.isEmpty()) continue
+                    add(
+                        buildJsonObject {
+                            put("type", kind)
+                            putJsonArray("challenges") {
+                                for (c in challenges) {
+                                    add(JsonPrimitive(c))
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+        val requestsJson = payloadJson.encodeToString(JsonElement.serializer(), requests)
+        val playerInput = QuickJsEngine.jsStringLiteral(playerInputText)
+        val payloadPrefix =
+            if (preprocessed) {
+                "{\"type\":\"preprocessed\",\"preprocessed_player\":"
+            } else {
+                "{\"type\":\"player\",\"player\":"
+            }
+        val payloadSuffix =
+            if (preprocessed) {
+                ",\"requests\":$requestsJson}"
+            } else {
+                ",\"output_preprocessed\":true,\"requests\":$requestsJson}"
+            }
+        if (payloadPrefix.length + playerInput.length + payloadSuffix.length > MAX_PAYLOAD_LENGTH) {
+            return SolveResult(emptyMap(), emptyMap(), null)
+        }
+        // jsc() may return objects QuickJS JSON.stringify cannot handle (circular refs);
+        // copy only plain string fields into a new tree before stringify.
+        val js =
+            """
+            (function() {
+              var payload = $payloadPrefix$playerInput$payloadSuffix;
+              var r = jsc(payload);
+              if (!r) return JSON.stringify({"type":"error","error":"jsc returned null"});
+              if (r.type === "error")
+                return JSON.stringify({"type":"error","error":String(r.error != null ? r.error : "")});
+              if (r.type !== "result")
+                return JSON.stringify({"type":"error","error":"unexpected jsc type: "+String(r.type)});
+              var out = {"type":"result","responses":[]};
+              if (typeof r.preprocessed_player === "string" && r.preprocessed_player.length > 0) {
+                if (r.preprocessed_player.length > $MAX_PLAYER_JS_LENGTH)
+                  return JSON.stringify({"type":"error","error":"preprocessed player too large"});
+                out.preprocessed_player = r.preprocessed_player;
+              }
+              var resps = r.responses;
+              if (!resps) return JSON.stringify(out);
+              for (var i = 0; i < resps.length; i++) {
+                var resp = resps[i];
+                if (!resp) {
+                  out.responses.push({"type":"error","error":"null response"});
+                  continue;
+                }
+                if (resp.type === "error") {
+                  out.responses.push({
+                    "type":"error",
+                    "error":String(resp.error != null ? resp.error : "")
+                  });
+                } else if (resp.type === "result") {
+                  var d = resp.data;
+                  var plain = {};
+                  if (d && typeof d === "object") {
+                    var keys = Object.keys(d);
+                    for (var j = 0; j < keys.length; j++) {
+                      var k = keys[j];
+                      var v = d[k];
+                      var text = v == null ? "" : String(v);
+                      if (text.length > $MAX_SOLVER_OUTPUT_LENGTH) {
+                        plain = null;
+                        break;
+                      }
+                      plain[k] = text;
+                    }
+                  }
+                  if (plain == null)
+                    out.responses.push({"type":"error","error":"solver output too large"});
+                  else
+                    out.responses.push({"type":"result","data":plain});
+                } else {
+                  out.responses.push({"type":"error","error":"unknown response type"});
+                }
+              }
+              return JSON.stringify(out);
+            })()
+            """.trimIndent()
+        val evaluateStartMs = Clock.System.now().toEpochMilliseconds()
+        val evaluated = engine.evaluate(js, MAX_RAW_OUTPUT_LENGTH, collectGarbage = !preprocessed)
+        if (evaluated.length > MAX_RAW_OUTPUT_LENGTH) return SolveResult(emptyMap(), emptyMap(), null)
+        val raw = evaluated.trim()
+        logger.d(
+            TAG,
+            "EJS evaluate done preprocessed=$preprocessed requests=${requestOrder.sumOf {
+                it.second.size
+            }} elapsed=${Clock.System.now().toEpochMilliseconds() - evaluateStartMs}ms player=${playerUrl.logId()}",
+        )
+        return parseOutput(playerUrl, raw, requestOrder)
+    }
+
+    private suspend fun loadPreprocessedPlayer(
+        playerUrl: String,
+        cacheKey: String?,
+    ): String? {
+        preprocessedMutex.withLock {
+            preprocessedByPlayerUrl.remove(playerUrl)?.also {
+                preprocessedByPlayerUrl[playerUrl] = it
+                return it
+            }
+        }
+        cacheKey ?: return null
+        val stored =
+            try {
+                readPreprocessedPlayer(cacheKey)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
+            } ?: return null
+        if (stored.isBlank() || stored.length > MAX_PLAYER_JS_LENGTH) {
+            safeWritePreprocessedPlayer(cacheKey, null)
+            return null
+        }
+        preprocessedMutex.withLock { putPreprocessedPlayerLocked(playerUrl, stored) }
+        return stored
+    }
+
+    private suspend fun persistPreprocessedPlayer(
+        cacheKey: String?,
+        preprocessedPlayer: String,
+    ) {
+        if (cacheKey != null && preprocessedPlayer.isNotBlank() && preprocessedPlayer.length <= MAX_PLAYER_JS_LENGTH) {
+            safeWritePreprocessedPlayer(cacheKey, preprocessedPlayer)
+        }
+    }
+
+    private suspend fun evictPreprocessedPlayer(
+        playerUrl: String,
+        cacheKey: String?,
+    ) {
+        preprocessedMutex.withLock { preprocessedByPlayerUrl.remove(playerUrl) }
+        cacheKey?.let { safeWritePreprocessedPlayer(it, null) }
+    }
+
+    private suspend fun safeWritePreprocessedPlayer(
+        cacheKey: String,
+        value: String?,
+    ) {
+        try {
+            writePreprocessedPlayer(cacheKey, value)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Cache failures must not break playback.
         }
     }
 
@@ -309,3 +409,23 @@ internal class EjsChallengeSolver(
 
     private fun Throwable.logType(): String = this::class.simpleName ?: "Exception"
 }
+
+internal fun preprocessedPlayerCacheKey(
+    playerUrl: String,
+    bundleHash: String,
+): String? {
+    if (!PREPROCESSED_CACHE_KEY_REGEX.matches(bundleHash)) return null
+    runCatching { validatedPlayerScriptUrl(playerUrl) }.getOrNull() ?: return null
+    return sha1("$playerUrl:$bundleHash")
+}
+
+private fun EjsChallengeSolver.SolveResult.solvesAll(requestOrder: List<Pair<String, List<String>>>): Boolean =
+    requestOrder.all { (kind, challenges) ->
+        val solved =
+            when (kind) {
+                "sig" -> sigByChallenge
+                "n" -> nByChallenge
+                else -> return@all false
+            }
+        challenges.all(solved::containsKey)
+    }

--- a/src/commonMain/kotlin/com/metrolist/innertubex/cipher/QuickJsEngine.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/cipher/QuickJsEngine.kt
@@ -89,11 +89,13 @@ internal class QuickJsEngine {
      * Execute JavaScript code and return the result.
      *
      * @param code The JavaScript code to execute
+     * @param collectGarbage Whether to collect unreachable cycles before returning
      * @return The result of the execution as a string
      */
     suspend fun evaluate(
         code: String,
         maxResultLength: Int,
+        collectGarbage: Boolean = false,
     ): String =
         withContext(Dispatchers.Default) {
             require(maxResultLength in 1..MAX_EVALUATION_RESULT_LENGTH) { "Invalid QuickJS result limit" }
@@ -108,7 +110,11 @@ internal class QuickJsEngine {
                       return text.length <= $maxResultLength ? text : "";
                     })()
                     """.trimIndent()
-                runtime.evaluateSafely<String?>(boundedCode).orEmpty()
+                try {
+                    runtime.evaluateSafely<String?>(boundedCode).orEmpty()
+                } finally {
+                    if (collectGarbage) runtime.gc()
+                }
             }
         }
 

--- a/src/commonMain/kotlin/com/metrolist/innertubex/cipher/YouTubeCipherService.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/cipher/YouTubeCipherService.kt
@@ -92,6 +92,15 @@ class YouTubeCipherService(
      */
     suspend fun initialize() = operationMutex.withLock { initializeUnsafe() }
 
+    /**
+     * Installs optional persistent storage for generated EJS preprocessed players.
+     * Passing null to [write] deletes an unusable cached value.
+     */
+    suspend fun setPreprocessedPlayerCache(
+        read: suspend (String) -> String?,
+        write: suspend (String, String?) -> Unit,
+    ) = operationMutex.withLock { ejs.setPreprocessedPlayerCache(read, write) }
+
     private suspend fun initializeUnsafe() {
         engine.initialize()
     }
@@ -834,24 +843,6 @@ class YouTubeCipherService(
         throw lastFailure ?: IllegalStateException("Player script request failed")
     }
 
-    private fun validatedPlayerScriptUrl(value: String): Url {
-        val url = Url(value)
-        val isYouTubeHost =
-            url.host == "youtube.com" ||
-                url.host.endsWith(".youtube.com") ||
-                url.host == "youtube-nocookie.com" ||
-                url.host.endsWith(".youtube-nocookie.com")
-        require(
-            url.protocol.name == "https" &&
-                isYouTubeHost &&
-                url.encodedPath.startsWith("/s/player/") &&
-                url.encodedPath.endsWith(".js"),
-        ) {
-            "Player script URL must use an approved YouTube HTTPS endpoint"
-        }
-        return url
-    }
-
     /**
      * Create a solver from the player JavaScript code using the parser (QuickJS _solveN / _solveSig).
      */
@@ -1054,4 +1045,22 @@ class YouTubeCipherService(
     private fun String.logId(): String = RemotePlayerConfigParser.extractPlayerHash(this) ?: "unknown"
 
     private fun Throwable.logType(): String = this::class.simpleName ?: "Exception"
+}
+
+internal fun validatedPlayerScriptUrl(value: String): Url {
+    val url = Url(value)
+    val isYouTubeHost =
+        url.host == "youtube.com" ||
+            url.host.endsWith(".youtube.com") ||
+            url.host == "youtube-nocookie.com" ||
+            url.host.endsWith(".youtube-nocookie.com")
+    require(
+        url.protocol.name == "https" &&
+            isYouTubeHost &&
+            url.encodedPath.startsWith("/s/player/") &&
+            url.encodedPath.endsWith(".js"),
+    ) {
+        "Player script URL must use an approved YouTube HTTPS endpoint"
+    }
+    return url
 }

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/FormatSelectors.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/FormatSelectors.kt
@@ -39,12 +39,12 @@ public fun selectBestVideoFormat(
     val videoFormats = validFormats.filter { it.width != null && (it.height ?: 0) > 0 }
     if (videoFormats.isEmpty()) return null
     val withinCap = videoFormats.filter { it.height!! <= maxHeight }
-    return withinCap.maxWithOrNull(compareBy(::videoFormatScore))
+    return withinCap.maxWithOrNull(videoFormatComparator)
         ?: videoFormats
             .groupBy { it.height!! }
             .minByOrNull { it.key }
             ?.value
-            ?.maxWithOrNull(compareBy(::videoFormatScore))
+            ?.maxWithOrNull(videoFormatComparator)
 }
 
 private fun audioFormatScore(format: Format): Int {
@@ -63,14 +63,14 @@ private fun audioFormatScore(format: Format): Int {
     return codecRank * 1_000_000 + channelBonus + format.bitrate + (format.audioSampleRate ?: 0).coerceIn(0, 48_000) / 10
 }
 
-private fun videoFormatScore(format: Format): Long {
-    val codec = format.mimeType.lowercase()
-    val codecRank =
-        when {
-            "vp09" in codec || "vp9" in codec || "video/webm" in codec -> 3L
-            "avc1" in codec || "video/mp4" in codec -> 2L
-            "av01" in codec -> 1L
-            else -> 0L
-        }
-    return (format.height ?: 0).toLong() * 1_000_000_000_000L + codecRank * 1_000_000_000L + format.bitrate
-}
+// AVC and VP9 both have broad native decoding support; avoid excess bitrate at the same resolution.
+private val videoFormatComparator =
+    compareBy<Format> { it.height ?: 0 }
+        .thenBy {
+            val codec = it.mimeType.lowercase()
+            when {
+                "av01" in codec -> 1
+                "avc1" in codec || "vp09" in codec || "vp9" in codec || "video/mp4" in codec || "video/webm" in codec -> 2
+                else -> 0
+            }
+        }.thenByDescending { it.bitrate.takeIf { bitrate -> bitrate > 0 } ?: Int.MAX_VALUE }

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
@@ -10,6 +10,8 @@ import com.metrolist.innertubex.extraction.strategy.ContentAwareFallbackStrategy
 import com.metrolist.innertubex.extraction.strategy.PlaybackClientCatalog
 import com.metrolist.innertubex.i
 import com.metrolist.innertubex.models.response.PlayerResponse
+import com.metrolist.innertubex.models.response.PlayerResponse.StreamingData
+import com.metrolist.innertubex.models.response.PlayerResponse.StreamingData.Format
 import com.metrolist.innertubex.sabr.ExperimentalSabrApi
 import com.metrolist.innertubex.sabr.requireAllowedSabrUrl
 import com.metrolist.innertubex.sabr.sabrRequestOrigin
@@ -719,7 +721,7 @@ class InnerTubeExtractor internal constructor(
                 val videoFormat =
                     if (hints.wantVideo) {
                         selectBestVideoFormat(
-                            formats = allFormats.filterNot(PlayerResponse.StreamingData.Format::isAudio),
+                            formats = preferredVideoFormats(streamingData, requireUrl = false),
                             requireUrl = false,
                             maxHeight = hints.maxVideoHeight ?: 2160,
                         )
@@ -882,7 +884,7 @@ class InnerTubeExtractor internal constructor(
             val directFastPathCandidate = selectBestAudioFormat(directAudioFormats, audioQuality)
             val wantVideo = hints.wantVideo
             val directVideoFormats =
-                if (wantVideo) allFormats.filter { it.width != null && !it.url.isNullOrBlank() } else emptyList()
+                if (wantVideo) preferredVideoFormats(streamingData, requireUrl = true) else emptyList()
             val directFastPathVideo = selectBestVideoFormat(directVideoFormats, maxHeight = hints.maxVideoHeight ?: 2160)
             if (directFastPathCandidate != null && (!wantVideo || directFastPathVideo != null)) {
                 val directUrl =
@@ -981,29 +983,23 @@ class InnerTubeExtractor internal constructor(
             val cipherStart = Clock.System.now().toEpochMilliseconds()
             val rawAudioFormats = allFormats.filter { it.width == null }
             val preferredRawAudioFormat = selectBestAudioFormat(rawAudioFormats, audioQuality, requireUrl = false)
-            val formatsForCipher = preferredRawAudioFormat?.let { listOf(it) } ?: rawAudioFormats
+            val audioFormatsForCipher = preferredRawAudioFormat?.let { listOf(it) } ?: rawAudioFormats
+            val rawVideoFormats = if (hints.wantVideo) preferredVideoFormats(streamingData, requireUrl = false) else emptyList()
+            val preferredRawVideoFormat =
+                selectBestVideoFormat(
+                    rawVideoFormats,
+                    requireUrl = false,
+                    maxHeight = hints.maxVideoHeight ?: 2160,
+                )
+            val formatsForCipher = audioFormatsForCipher + listOfNotNull(preferredRawVideoFormat)
             var processedFormats =
                 cipherService.processFormats(
                     playerUrl = playerConfig.playerUrl,
                     formats = formatsForCipher,
                 )
-            val rawVideoFormats = if (hints.wantVideo) allFormats.filter { it.width != null } else emptyList()
-            val preferredRawVideoFormat =
-                selectBestVideoFormat(
-                    rawVideoFormats,
-                    requireUrl = false,
-                    maxHeight =
-                        hints.maxVideoHeight ?: 2160,
-                )
             val processedVideoFormat =
-                if (preferredRawVideoFormat != null) {
-                    cipherService
-                        .processFormats(
-                            playerUrl = playerConfig.playerUrl,
-                            formats = listOf(preferredRawVideoFormat),
-                        ).firstOrNull { !it.url.isNullOrBlank() }
-                } else {
-                    null
+                preferredRawVideoFormat?.let { preferred ->
+                    processedFormats.firstOrNull { it.itag == preferred.itag && it.width != null && !it.url.isNullOrBlank() }
                 }
             logger.d(
                 TAG,
@@ -1017,14 +1013,14 @@ class InnerTubeExtractor internal constructor(
                     ),
             )
 
-            var audioFormats = processedFormats
+            var audioFormats = processedFormats.filter(PlayerResponse.StreamingData.Format::isAudio)
             var usableAudioFormats = audioFormats.filter { !it.url.isNullOrBlank() }
             var directUrlAudioFormats = usableAudioFormats.filter { it.itag in directAudioItags }
             var selectionPool =
                 directUrlAudioFormats.ifEmpty { usableAudioFormats }
             var audioFormat = selectBestAudioFormat(selectionPool, audioQuality)
 
-            if (audioFormat == null && formatsForCipher.size != rawAudioFormats.size) {
+            if (audioFormat == null && audioFormatsForCipher.size != rawAudioFormats.size) {
                 val fallbackCipherStart = Clock.System.now().toEpochMilliseconds()
                 processedFormats =
                     cipherService.processFormats(
@@ -1369,6 +1365,18 @@ class InnerTubeExtractor internal constructor(
                 isLive = details.isLiveContent == true,
             )
         }
+
+    private fun preferredVideoFormats(
+        streamingData: StreamingData,
+        requireUrl: Boolean,
+    ): List<Format> {
+        val adaptive = streamingData.adaptiveFormats.filter { it.width != null && (!requireUrl || !it.url.isNullOrBlank()) }
+        val adaptiveHeights = adaptive.mapTo(mutableSetOf()) { it.height }
+        return adaptive +
+            streamingData.formats.orEmpty().filter {
+                it.width != null && it.height !in adaptiveHeights && (!requireUrl || !it.url.isNullOrBlank())
+            }
+    }
 
     private fun String.extractCodecs(): String? = Regex("codecs=\"([^\"]+)\"").find(this)?.groupValues?.getOrNull(1)
 

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
@@ -18,7 +18,6 @@ import com.metrolist.innertubex.w
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
@@ -181,40 +180,15 @@ class InnerTubeExtractor internal constructor(
                 maxPlayerRequests = if (hints.playbackClientOverrideId != null) 1 else MAX_PLAYER_REQUESTS_PER_EXTRACTION,
             )
         return try {
-            coroutineScope {
-                val session = innerTube.sessionSnapshot()
-                val prefetchedPoToken =
-                    if (
-                        hints.isExplicit == true &&
-                        hints.playbackClientOverrideId == null &&
-                        !session.visitorData.isNullOrBlank() &&
-                        tokenProvider.capabilities.providers.isNotEmpty()
-                    ) {
-                        async {
-                            withTimeoutOrNull(PO_TOKEN_PREFETCH_TIMEOUT) {
-                                try {
-                                    tokenProvider.getPoToken(videoId, session.visitorData, session.cookie)
-                                } catch (e: CancellationException) {
-                                    throw e
-                                } catch (_: Exception) {
-                                    null
-                                }
-                            }
-                        }
-                    } else {
-                        null
-                    }
-                extractWithDiagnostics(
-                    videoId,
-                    hints,
-                    excludedClients,
-                    audioQuality,
-                    clientPlaybackNonce,
-                    totalStart,
-                    diagnostics,
-                    prefetchedPoToken,
-                )
-            }
+            extractWithDiagnostics(
+                videoId,
+                hints,
+                excludedClients,
+                audioQuality,
+                clientPlaybackNonce,
+                totalStart,
+                diagnostics,
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: StreamResolveException) {
@@ -243,7 +217,6 @@ class InnerTubeExtractor internal constructor(
         clientPlaybackNonce: String,
         totalStart: Long,
         diagnostics: ExtractionDiagnostics,
-        prefetchedPoToken: Deferred<PoTokenResult?>? = null,
     ): ExtractedStream? {
         logger.d(
             TAG,
@@ -273,6 +246,26 @@ class InnerTubeExtractor internal constructor(
             throwExtractionFailure(hints, diagnostics)
         }
 
+        if (
+            hints.playbackClientOverrideId == null && !hints.wantVideo &&
+            hints.isExplicit != true && hints.isAgeRestricted != true &&
+            hints.isUploaded != true && hints.isLive != true
+        ) {
+            val directStream =
+                extractWithConfig(
+                    videoId = videoId,
+                    hints = hints,
+                    excludedClients = excludedClients,
+                    clientPlaybackNonce = clientPlaybackNonce,
+                    playerConfig = PlayerConfig("", null, innerTube.sessionSnapshot().visitorData, null),
+                    totalStartMs = totalStart,
+                    allowCipherProcessing = false,
+                    audioQuality = audioQuality,
+                    diagnostics = diagnostics,
+                )
+            if (directStream != null) return directStream
+        }
+
         val cookieFirst = hints.isExplicit == true && innerTube.hasSapCookieAuth()
         val stream =
             extractWithCachedConfig(
@@ -284,7 +277,6 @@ class InnerTubeExtractor internal constructor(
                 totalStartMs = totalStart,
                 audioQuality = audioQuality,
                 diagnostics = diagnostics,
-                prefetchedPoToken = prefetchedPoToken,
             )
         if (stream != null) return stream
 
@@ -300,7 +292,6 @@ class InnerTubeExtractor internal constructor(
                     totalStartMs = totalStart,
                     audioQuality = audioQuality,
                     diagnostics = diagnostics,
-                    prefetchedPoToken = prefetchedPoToken,
                 )
             if (authenticatedStream != null) return authenticatedStream
         }
@@ -483,7 +474,6 @@ class InnerTubeExtractor internal constructor(
         totalStartMs: Long,
         audioQuality: AudioQuality = AudioQuality.AUTO,
         diagnostics: ExtractionDiagnostics,
-        prefetchedPoToken: Deferred<PoTokenResult?>? = null,
     ): ExtractedStream? {
         val nowMs = Clock.System.now().toEpochMilliseconds()
         val cachedConfig = getCachedPlayerConfig(useLoginCookies, nowMs)
@@ -510,7 +500,6 @@ class InnerTubeExtractor internal constructor(
                     totalStartMs = totalStartMs,
                     audioQuality = audioQuality,
                     diagnostics = diagnostics,
-                    prefetchedPoToken = prefetchedPoToken,
                 )
             if (cachedStream != null) return cachedStream
             logger.w(TAG, "watch page cache unusable", details = mapOf("authenticated" to useLoginCookies.toString()))
@@ -520,6 +509,10 @@ class InnerTubeExtractor internal constructor(
         var fetchedFreshConfig = false
         val freshCachedConfig =
             playerConfigFetchMutex.withLock {
+                if (cachedConfig != null && playerConfigCache[useLoginCookies] === cachedConfig) {
+                    playerConfigCache.remove(useLoginCookies)
+                }
+                if (diagnostics.requestBudget.remaining <= 0) return null
                 getCachedPlayerConfigLocked(useLoginCookies, Clock.System.now().toEpochMilliseconds())
                     ?: run {
                         val expectedSession = innerTube.sessionSnapshot()
@@ -552,7 +545,6 @@ class InnerTubeExtractor internal constructor(
             totalStartMs = totalStartMs,
             audioQuality = audioQuality,
             diagnostics = diagnostics,
-            prefetchedPoToken = prefetchedPoToken,
         )
     }
 
@@ -602,7 +594,6 @@ class InnerTubeExtractor internal constructor(
         allowCipherProcessing: Boolean = true,
         audioQuality: AudioQuality = AudioQuality.AUTO,
         diagnostics: ExtractionDiagnostics,
-        prefetchedPoToken: Deferred<PoTokenResult?>? = null,
     ): ExtractedStream? {
         if (diagnostics.requestBudget.remaining <= 0) return null
         logger.d(
@@ -626,7 +617,6 @@ class InnerTubeExtractor internal constructor(
                 directAudioOnlyClients = !allowCipherProcessing && !hints.wantVideo,
                 wantVideo = hints.wantVideo,
                 requestBudget = diagnostics.requestBudget,
-                prefetchedPoToken = prefetchedPoToken,
             )
         diagnostics.failures += batch.failures
         diagnostics.requestFailures += batch.requestFailures

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
@@ -18,6 +18,7 @@ import com.metrolist.innertubex.w
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
@@ -68,7 +69,9 @@ class InnerTubeExtractor internal constructor(
         private const val WEB_EMBEDDED_PLAYER_ID = "WEB_EMBEDDED_PLAYER"
         private const val WEB_KIDS_ID = "WEB_KIDS"
         private val PO_TOKEN_PREFETCH_TIMEOUT = 18.seconds
-        private val MAX_PLAYER_REQUESTS_PER_EXTRACTION = PlaybackClientCatalog.automaticManifests.size * 2 + 2
+
+        // Allow a cached-config pass and a fresh-config pass, plus native probes.
+        private val MAX_PLAYER_REQUESTS_PER_EXTRACTION = PlaybackClientCatalog.automaticManifests.size * 4 + 2
     }
 
     private data class CachedPlayerConfig(
@@ -180,15 +183,42 @@ class InnerTubeExtractor internal constructor(
                 maxPlayerRequests = if (hints.playbackClientOverrideId != null) 1 else MAX_PLAYER_REQUESTS_PER_EXTRACTION,
             )
         return try {
-            extractWithDiagnostics(
-                videoId,
-                hints,
-                excludedClients,
-                audioQuality,
-                clientPlaybackNonce,
-                totalStart,
-                diagnostics,
-            )
+            coroutineScope {
+                val session = innerTube.sessionSnapshot()
+                val prefetchedPoToken =
+                    if (
+                        hints.isExplicit == true && hints.playbackClientOverrideId == null &&
+                        !session.visitorData.isNullOrBlank() && tokenProvider.capabilities.providers.isNotEmpty()
+                    ) {
+                        async {
+                            withTimeoutOrNull(PO_TOKEN_PREFETCH_TIMEOUT) {
+                                try {
+                                    tokenProvider.getPoToken(videoId, session.visitorData, session.cookie)
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (_: Exception) {
+                                    null
+                                }
+                            }
+                        }
+                    } else {
+                        null
+                    }
+                try {
+                    extractWithDiagnostics(
+                        videoId,
+                        hints,
+                        excludedClients,
+                        audioQuality,
+                        clientPlaybackNonce,
+                        totalStart,
+                        diagnostics,
+                        prefetchedPoToken,
+                    )
+                } finally {
+                    prefetchedPoToken?.cancel()
+                }
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: StreamResolveException) {
@@ -217,6 +247,7 @@ class InnerTubeExtractor internal constructor(
         clientPlaybackNonce: String,
         totalStart: Long,
         diagnostics: ExtractionDiagnostics,
+        prefetchedPoToken: Deferred<PoTokenResult?>? = null,
     ): ExtractedStream? {
         logger.d(
             TAG,
@@ -277,6 +308,7 @@ class InnerTubeExtractor internal constructor(
                 totalStartMs = totalStart,
                 audioQuality = audioQuality,
                 diagnostics = diagnostics,
+                prefetchedPoToken = prefetchedPoToken,
             )
         if (stream != null) return stream
 
@@ -292,6 +324,7 @@ class InnerTubeExtractor internal constructor(
                     totalStartMs = totalStart,
                     audioQuality = audioQuality,
                     diagnostics = diagnostics,
+                    prefetchedPoToken = prefetchedPoToken,
                 )
             if (authenticatedStream != null) return authenticatedStream
         }
@@ -474,6 +507,7 @@ class InnerTubeExtractor internal constructor(
         totalStartMs: Long,
         audioQuality: AudioQuality = AudioQuality.AUTO,
         diagnostics: ExtractionDiagnostics,
+        prefetchedPoToken: Deferred<PoTokenResult?>? = null,
     ): ExtractedStream? {
         val nowMs = Clock.System.now().toEpochMilliseconds()
         val cachedConfig = getCachedPlayerConfig(useLoginCookies, nowMs)
@@ -500,6 +534,7 @@ class InnerTubeExtractor internal constructor(
                     totalStartMs = totalStartMs,
                     audioQuality = audioQuality,
                     diagnostics = diagnostics,
+                    prefetchedPoToken = prefetchedPoToken,
                 )
             if (cachedStream != null) return cachedStream
             logger.w(TAG, "watch page cache unusable", details = mapOf("authenticated" to useLoginCookies.toString()))
@@ -545,6 +580,7 @@ class InnerTubeExtractor internal constructor(
             totalStartMs = totalStartMs,
             audioQuality = audioQuality,
             diagnostics = diagnostics,
+            prefetchedPoToken = prefetchedPoToken,
         )
     }
 
@@ -594,6 +630,7 @@ class InnerTubeExtractor internal constructor(
         allowCipherProcessing: Boolean = true,
         audioQuality: AudioQuality = AudioQuality.AUTO,
         diagnostics: ExtractionDiagnostics,
+        prefetchedPoToken: Deferred<PoTokenResult?>? = null,
     ): ExtractedStream? {
         if (diagnostics.requestBudget.remaining <= 0) return null
         logger.d(
@@ -617,6 +654,7 @@ class InnerTubeExtractor internal constructor(
                 directAudioOnlyClients = !allowCipherProcessing && !hints.wantVideo,
                 wantVideo = hints.wantVideo,
                 requestBudget = diagnostics.requestBudget,
+                prefetchedPoToken = prefetchedPoToken,
             )
         diagnostics.failures += batch.failures
         diagnostics.requestFailures += batch.requestFailures

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractor.kt
@@ -885,7 +885,17 @@ class InnerTubeExtractor internal constructor(
             val wantVideo = hints.wantVideo
             val directVideoFormats =
                 if (wantVideo) preferredVideoFormats(streamingData, requireUrl = true) else emptyList()
-            val directFastPathVideo = selectBestVideoFormat(directVideoFormats, maxHeight = hints.maxVideoHeight ?: 2160)
+            val preferredDirectVideo =
+                selectBestVideoFormat(directVideoFormats, maxHeight = hints.maxVideoHeight ?: 2160)
+            val directFastPathVideo =
+                preferredDirectVideo?.takeIf { it.hasReadyVideoUrl() }
+                    ?: selectBestVideoFormat(
+                        directVideoFormats.filter {
+                            it.height == preferredDirectVideo?.height && it.hasReadyVideoUrl()
+                        },
+                        maxHeight = hints.maxVideoHeight ?: 2160,
+                    )
+                    ?: preferredDirectVideo
             if (directFastPathCandidate != null && (!wantVideo || directFastPathVideo != null)) {
                 val directUrl =
                     appendClientPlaybackNonce(
@@ -991,15 +1001,31 @@ class InnerTubeExtractor internal constructor(
                     requireUrl = false,
                     maxHeight = hints.maxVideoHeight ?: 2160,
                 )
-            val formatsForCipher = audioFormatsForCipher + listOfNotNull(preferredRawVideoFormat)
+            val rawVideoFallback =
+                if (preferredRawVideoFormat?.hasReadyVideoUrl() == true) {
+                    null
+                } else {
+                    selectBestVideoFormat(
+                        rawVideoFormats.filter {
+                            it.itag != preferredRawVideoFormat?.itag &&
+                                it.height == preferredRawVideoFormat?.height &&
+                                it.hasReadyVideoUrl()
+                        },
+                        maxHeight = hints.maxVideoHeight ?: 2160,
+                    )
+                }
+            val rawVideoCandidates = listOfNotNull(preferredRawVideoFormat, rawVideoFallback)
+            val formatsForCipher = audioFormatsForCipher + rawVideoCandidates
             var processedFormats =
                 cipherService.processFormats(
                     playerUrl = playerConfig.playerUrl,
                     formats = formatsForCipher,
                 )
             val processedVideoFormat =
-                preferredRawVideoFormat?.let { preferred ->
-                    processedFormats.firstOrNull { it.itag == preferred.itag && it.width != null && !it.url.isNullOrBlank() }
+                rawVideoCandidates.firstNotNullOfOrNull { candidate ->
+                    processedFormats.firstOrNull {
+                        it.itag == candidate.itag && it.width != null && it.hasReadyVideoUrl()
+                    }
                 }
             logger.d(
                 TAG,
@@ -1371,7 +1397,7 @@ class InnerTubeExtractor internal constructor(
         requireUrl: Boolean,
     ): List<Format> {
         val adaptive = streamingData.adaptiveFormats.filter { it.width != null && (!requireUrl || !it.url.isNullOrBlank()) }
-        val adaptiveHeights = adaptive.mapTo(mutableSetOf()) { it.height }
+        val adaptiveHeights = adaptive.filter { it.hasReadyVideoUrl() }.mapTo(mutableSetOf()) { it.height }
         return adaptive +
             streamingData.formats.orEmpty().filter {
                 it.width != null && it.height !in adaptiveHeights && (!requireUrl || !it.url.isNullOrBlank())
@@ -1379,6 +1405,8 @@ class InnerTubeExtractor internal constructor(
     }
 
     private fun String.extractCodecs(): String? = Regex("codecs=\"([^\"]+)\"").find(this)?.groupValues?.getOrNull(1)
+
+    private fun Format.hasReadyVideoUrl(): Boolean = url?.let { !it.hasNParameter() && isAllowedMediaUrl(it) } == true
 
     private fun isAllowedMediaUrl(value: String): Boolean =
         runCatching { Url(value) }.getOrNull()?.let {

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/YtConfigParserImpl.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/YtConfigParserImpl.kt
@@ -174,7 +174,7 @@ public class YtConfigParserImpl(
 
     internal fun extractSignatureTimestamp(html: String): Int? =
         listOf(
-            Regex("(?:signatureTimestamp|sts)\\s*:\\s*([0-9]{5})"),
+            Regex("(?:signatureTimestamp|sts)\"?\\s*:\\s*([0-9]{5})"),
             Regex("\"STS\":\\s*([0-9]{5})"),
         ).asSequence()
             .mapNotNull {

--- a/src/commonMain/kotlin/com/metrolist/innertubex/extraction/strategy/ContentAwareFallbackStrategy.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/extraction/strategy/ContentAwareFallbackStrategy.kt
@@ -62,9 +62,21 @@ class ContentAwareFallbackStrategy(
             candidates.sortedWith(
                 compareBy<SelectedClient> {
                     when (request.transportPreference) {
-                        PlaybackTransportPreference.AUTO -> if (it.client.useSabr) 1 else 0
-                        PlaybackTransportPreference.SABR -> if (it.client.useSabr) 0 else 1
-                        else -> 0
+                        PlaybackTransportPreference.AUTO -> {
+                            when {
+                                it.client.useSabr -> 2
+                                request.hints.isKidsContent == true && it.client == YouTubeClient.WEB_KIDS -> 0
+                                else -> 1
+                            }
+                        }
+
+                        PlaybackTransportPreference.SABR -> {
+                            if (it.client.useSabr) 0 else 1
+                        }
+
+                        else -> {
+                            0
+                        }
                     }
                 }.thenByDescending { it.score }
                     .thenBy { it.manifest?.id },
@@ -123,6 +135,7 @@ class ContentAwareFallbackStrategy(
             }
 
             if (request.fastPathOnly) {
+                if (manifest.request.signatureTimestamp) add("watch config excluded from fast path")
                 val requiresToken =
                     listOf(manifest.poTokens.player, manifest.poTokens.gvs).any {
                         it.requirement == PoTokenRequirement.REQUIRED && !(request.premium && it.premiumMayBypass)

--- a/src/commonMain/kotlin/com/metrolist/innertubex/sabr/SabrAudioStream.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/sabr/SabrAudioStream.kt
@@ -144,6 +144,7 @@ private class SabrMediaStream(
             var backoffTimeMs = 0L
             var requestsWithoutProgress = 0
             var ended = false
+            var firstSequenceNumber: Int? = null
             var lastSequenceNumber: Int? = null
             var consecutiveTransientFailures = 0
             var transientRetryCount = 0
@@ -287,6 +288,7 @@ private class SabrMediaStream(
 
                             suspend fun emitMediaSegment(segment: SabrSegment) {
                                 send(segment.toChunk())
+                                if (firstSequenceNumber == null) firstSequenceNumber = segment.header.sequenceNumber
                                 lastSequenceNumber = segment.header.sequenceNumber
                                 playerTimeMs = maxOf(playerTimeMs, segment.checkedEndTimeMs())
                                 cumulativeMediaBytes += segment.data.size
@@ -356,7 +358,11 @@ private class SabrMediaStream(
                                             }
                                         } else {
                                             val sequenceNumber = segment.header.sequenceNumber
-                                            if (lastSequenceNumber?.let { sequenceNumber <= it } != true) {
+                                            val alreadyEmitted =
+                                                lastSequenceNumber?.let { last ->
+                                                    sequenceNumber >= checkNotNull(firstSequenceNumber) && sequenceNumber <= last
+                                                } == true
+                                            if (!alreadyEmitted) {
                                                 if (pendingMediaBySequence.put(sequenceNumber, segment) != null) {
                                                     throw SabrProtocolException("SABR returned duplicate segment $sequenceNumber")
                                                 }

--- a/src/commonMain/kotlin/com/metrolist/innertubex/sabr/SabrAudioStream.kt
+++ b/src/commonMain/kotlin/com/metrolist/innertubex/sabr/SabrAudioStream.kt
@@ -153,7 +153,6 @@ private class SabrMediaStream(
             var protectionPending = false
             var protectionRetryCount = 0
             var protectionRetryLimit: Int? = null
-            val emittedSequences = mutableSetOf<Int>()
             val contexts = mutableMapOf<Int, SabrContext>()
             val activeContextTypes = mutableSetOf<Int>()
             var retainedContextBytes = 0L
@@ -280,17 +279,28 @@ private class SabrMediaStream(
                             var responseProtectionStatus: Int? = null
                             var responseProtectionMaxRetries: Int? = null
                             val pendingMediaBySequence = linkedMapOf<Int, SabrSegment>()
-                            val newSegments = mutableListOf<SabrSegment>()
+                            var firstNewSegmentHeader: SabrMediaHeader? = null
+                            var lastNewSegmentHeader: SabrMediaHeader? = null
+                            var newSegmentsDurationMs = 0L
+                            var newSegmentsBytes = 0L
+                            var newSegmentCount = 0
 
                             suspend fun emitMediaSegment(segment: SabrSegment) {
                                 send(segment.toChunk())
-                                emittedSequences += segment.header.sequenceNumber
                                 lastSequenceNumber = segment.header.sequenceNumber
                                 playerTimeMs = maxOf(playerTimeMs, segment.checkedEndTimeMs())
                                 cumulativeMediaBytes += segment.data.size
                                 cumulativeStreamBytes += segment.data.size
                                 cumulativeSegmentCount++
-                                newSegments += segment
+                                val durationMs = segment.header.durationMs
+                                if (newSegmentsDurationMs > Long.MAX_VALUE - durationMs) {
+                                    throw SabrProtocolException("SABR buffered duration exceeded the supported range")
+                                }
+                                if (firstNewSegmentHeader == null) firstNewSegmentHeader = segment.header
+                                lastNewSegmentHeader = segment.header
+                                newSegmentsDurationMs += durationMs
+                                newSegmentsBytes += segment.data.size
+                                newSegmentCount++
                             }
 
                             suspend fun emitReadyMediaSegments(establishFromMinimum: Boolean = false) {
@@ -346,7 +356,7 @@ private class SabrMediaStream(
                                             }
                                         } else {
                                             val sequenceNumber = segment.header.sequenceNumber
-                                            if (sequenceNumber !in emittedSequences) {
+                                            if (lastSequenceNumber?.let { sequenceNumber <= it } != true) {
                                                 if (pendingMediaBySequence.put(sequenceNumber, segment) != null) {
                                                     throw SabrProtocolException("SABR returned duplicate segment $sequenceNumber")
                                                 }
@@ -467,18 +477,18 @@ private class SabrMediaStream(
                                 throw error
                             }
 
-                            if (newSegments.isNotEmpty()) {
+                            if (newSegmentCount > 0) {
                                 requestsWithoutProgress = 0
-                                val firstBufferedSegment = newSegments.first()
-                                val lastBufferedSegment = newSegments.last()
+                                val firstBufferedSegment = checkNotNull(firstNewSegmentHeader)
+                                val lastBufferedSegment = checkNotNull(lastNewSegmentHeader)
                                 bufferedRanges =
                                     listOf(
                                         SabrBufferedRange(
                                             formatId = selectedFormat,
-                                            startTimeMs = firstBufferedSegment.header.startMs,
-                                            durationMs = newSegments.checkedDurationSum(),
-                                            startSegmentIndex = firstBufferedSegment.header.sequenceNumber,
-                                            endSegmentIndex = lastBufferedSegment.header.sequenceNumber,
+                                            startTimeMs = firstBufferedSegment.startMs,
+                                            durationMs = newSegmentsDurationMs,
+                                            startSegmentIndex = firstBufferedSegment.sequenceNumber,
+                                            endSegmentIndex = lastBufferedSegment.sequenceNumber,
                                         ),
                                     )
                             } else {
@@ -522,9 +532,9 @@ private class SabrMediaStream(
                                     maxTimeSinceLastRequestMs = maxTimeSinceLastRequestMs,
                                     backoffTimeMs = backoffTimeMs,
                                     responseBytes = responseBytes,
-                                    selectedMediaBytes = newSegments.sumOf { it.data.size.toLong() },
+                                    selectedMediaBytes = newSegmentsBytes,
                                     cumulativeMediaBytes = cumulativeMediaBytes,
-                                    selectedSegmentCount = newSegments.size,
+                                    selectedSegmentCount = newSegmentCount,
                                     cumulativeSegmentCount = cumulativeSegmentCount,
                                     transientRetryCount = transientRetryCount,
                                     noProgressRequestCount = requestsWithoutProgress,
@@ -538,7 +548,7 @@ private class SabrMediaStream(
                                 protectionRetryLimit?.let { protectionRetryCount > it } == true
                             val protectionRequired =
                                 responseProtectionStatus?.let { it >= PROTECTION_ATTESTATION_REQUIRED } == true
-                            if (protectionPending && (protectionRequired || newSegments.isEmpty() || protectionRetriesExhausted)) {
+                            if (protectionPending && (protectionRequired || newSegmentCount == 0 || protectionRetriesExhausted)) {
                                 throw SabrProtocolException(
                                     "SABR stream protection requires attestation " +
                                         "(status ${responseProtectionStatus ?: PROTECTION_ATTESTATION_PENDING}, " +
@@ -547,7 +557,7 @@ private class SabrMediaStream(
                                 )
                             }
 
-                            if (newSegments.isEmpty() && !ended) {
+                            if (newSegmentCount == 0 && !ended) {
                                 val playbackPosition = playbackPositionMs?.invoke()?.coerceAtLeast(0L)
                                 val hasSafeReadahead = playbackPosition != null && playerTimeMs - playbackPosition > STARVATION_TOLERANCE_MS
                                 if (hasSafeReadahead) {
@@ -772,18 +782,6 @@ private class SabrMediaStream(
             throw SabrProtocolException("SABR segment has an invalid time range")
         }
         return startMs + durationMs
-    }
-
-    private fun List<SabrSegment>.checkedDurationSum(): Long {
-        var total = 0L
-        forEach { segment ->
-            val durationMs = segment.header.durationMs
-            if (durationMs < 0L || total > Long.MAX_VALUE - durationMs) {
-                throw SabrProtocolException("SABR buffered duration exceeded the supported range")
-            }
-            total += durationMs
-        }
-        return total
     }
 
     private companion object {

--- a/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
@@ -99,6 +99,100 @@ class InnerTubeExtractorTest {
         }
 
     @Test
+    fun adaptiveVideoIsPreferredOverHigherBitrateProgressiveVideo() =
+        runBlocking {
+            val client = jsonClient(PROGRESSIVE_AND_ADAPTIVE_VIDEO_RESPONSE)
+            val stream = extractor(client).extract("video", ContentHints(isExplicit = true, wantVideo = true))
+
+            assertNotNull(stream)
+            assertEquals(136, stream.videoItag)
+            client.close()
+        }
+
+    @Test
+    fun progressiveVideoStillProvidesResolutionsMissingFromAdaptiveVideo() =
+        runBlocking {
+            val response =
+                PROGRESSIVE_AND_ADAPTIVE_VIDEO_RESPONSE.replace(
+                    "\"bitrate\":5000000,\"width\":1280,\"height\":720",
+                    "\"bitrate\":5000000,\"width\":1920,\"height\":1080",
+                )
+            val client = jsonClient(response)
+            val stream = extractor(client).extract("video", ContentHints(isExplicit = true, wantVideo = true, maxVideoHeight = 1080))
+            assertNotNull(stream)
+            assertEquals(22, stream.videoItag)
+            client.close()
+        }
+
+    @Test
+    fun adaptivePreferenceDoesNotExceedTheRequestedResolution() =
+        runBlocking {
+            val response =
+                PROGRESSIVE_AND_ADAPTIVE_VIDEO_RESPONSE.replace(
+                    "\"bitrate\":1000000,\"width\":1280,\"height\":720",
+                    "\"bitrate\":1000000,\"width\":1920,\"height\":1080",
+                )
+            val client = jsonClient(response)
+            val stream = extractor(client).extract("video", ContentHints(isExplicit = true, wantVideo = true, maxVideoHeight = 720))
+            assertNotNull(stream)
+            assertEquals(22, stream.videoItag)
+            client.close()
+        }
+
+    @Test
+    fun readyProgressiveVideoDoesNotTriggerCipherWorkForAdaptiveVideo() =
+        runBlocking {
+            val response =
+                PROGRESSIVE_AND_ADAPTIVE_VIDEO_RESPONSE.replace(
+                    "\"url\":\"https://r.googlevideo.com/videoplayback?stream=adaptive\"",
+                    "\"signatureCipher\":\"url=https%3A%2F%2Fr.googlevideo.com%2Fvideoplayback&sp=sig&s=encrypted\"",
+                )
+            val client = jsonClient(response)
+            val cipher = RecordingCipherService()
+            val stream =
+                makeExtractor(
+                    client = client,
+                    innerTube = InnerTube(client, retryDelay = {}),
+                    parser = CountingParser(),
+                    cipherService = cipher,
+                ).extract("video", ContentHints(isExplicit = true, wantVideo = true))
+            assertNotNull(stream)
+            assertEquals(22, stream.videoItag)
+            assertTrue(cipher.calls.isEmpty())
+            client.close()
+        }
+
+    @Test
+    fun progressiveVideoRemainsFallbackWhenAdaptiveVideoIsMissing() =
+        runBlocking {
+            val client = jsonClient(PROGRESSIVE_VIDEO_FALLBACK_RESPONSE)
+            val stream = extractor(client).extract("video", ContentHints(isExplicit = true, wantVideo = true))
+
+            assertNotNull(stream)
+            assertEquals(22, stream.videoItag)
+            client.close()
+        }
+
+    @Test
+    fun selectedAudioAndVideoAreProcessedInOneCipherBatch() =
+        runBlocking {
+            val client = jsonClient(CIPHERED_VIDEO_RESPONSE)
+            val cipherService = RecordingCipherService()
+            val stream =
+                makeExtractor(
+                    client = client,
+                    innerTube = InnerTube(client, retryDelay = {}),
+                    parser = CountingParser(),
+                    cipherService = cipherService,
+                ).extract("video", ContentHints(isExplicit = true, wantVideo = true))
+
+            assertNotNull(stream)
+            assertEquals(136, stream.videoItag)
+            assertEquals(listOf(listOf(251, 136)), cipherService.calls)
+            client.close()
+        }
+
+    @Test
     fun normalDirectPlaybackSkipsWatchPageAndCipherSetup() =
         runBlocking {
             val client = jsonClient(DIRECT_RESPONSE)
@@ -840,6 +934,26 @@ class InnerTubeExtractorTest {
         ): List<PlayerResponse.StreamingData.Format> = formats.filter(PlayerResponse.StreamingData.Format::isAudio)
     }
 
+    private class RecordingCipherService : ExtractionCipherService {
+        val calls = mutableListOf<List<Int>>()
+
+        override suspend fun initialize() {}
+
+        override suspend fun preloadPlayerCode(playerUrl: String) {}
+
+        override suspend fun prewarmEjs() {}
+
+        override suspend fun processFormats(
+            playerUrl: String,
+            formats: List<PlayerResponse.StreamingData.Format>,
+        ): List<PlayerResponse.StreamingData.Format> {
+            calls += formats.map { it.itag }
+            return formats.map { format ->
+                format.copy(url = format.url ?: "https://r.googlevideo.com/videoplayback?itag=${format.itag}")
+            }
+        }
+    }
+
     private companion object {
         val DIRECT_RESPONSE =
             """
@@ -852,6 +966,14 @@ class InnerTubeExtractorTest {
         val CIPHERED_VIDEO_RESPONSE =
             """
             {"playabilityStatus":{"status":"OK"},"streamingData":{"adaptiveFormats":[{"itag":251,"url":"https://r.googlevideo.com/videoplayback","mimeType":"audio/webm","bitrate":128000},{"itag":136,"signatureCipher":"url=https%3A%2F%2Fr.googlevideo.com%2Fvideoplayback&sp=sig&s=encrypted","mimeType":"video/mp4; codecs=\"avc1\"","bitrate":1000000,"width":1280,"height":720}]}}
+            """.trimIndent()
+        val PROGRESSIVE_AND_ADAPTIVE_VIDEO_RESPONSE =
+            """
+            {"playabilityStatus":{"status":"OK"},"streamingData":{"formats":[{"itag":22,"url":"https://r.googlevideo.com/videoplayback?stream=progressive","mimeType":"video/mp4; codecs=\"avc1\"","bitrate":5000000,"width":1280,"height":720}],"adaptiveFormats":[{"itag":251,"url":"https://r.googlevideo.com/videoplayback?stream=audio","mimeType":"audio/webm","bitrate":128000},{"itag":136,"url":"https://r.googlevideo.com/videoplayback?stream=adaptive","mimeType":"video/mp4; codecs=\"avc1\"","bitrate":1000000,"width":1280,"height":720}]}}
+            """.trimIndent()
+        val PROGRESSIVE_VIDEO_FALLBACK_RESPONSE =
+            """
+            {"playabilityStatus":{"status":"OK"},"streamingData":{"formats":[{"itag":22,"url":"https://r.googlevideo.com/videoplayback?stream=progressive","mimeType":"video/mp4; codecs=\"avc1\"","bitrate":5000000,"width":1280,"height":720}],"adaptiveFormats":[{"itag":251,"url":"https://r.googlevideo.com/videoplayback?stream=audio","mimeType":"audio/webm","bitrate":128000}]}}
             """.trimIndent()
         val BOUNDED_VIDEO_RESPONSE =
             """

--- a/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
@@ -98,6 +98,35 @@ class InnerTubeExtractorTest {
         }
 
     @Test
+    fun normalDirectPlaybackSkipsWatchPageAndCipherSetup() =
+        runBlocking {
+            val client = jsonClient(DIRECT_RESPONSE)
+            val parser = CountingParser()
+            try {
+                val extractor = makeExtractor(client, InnerTube(client, retryDelay = {}), parser)
+                assertNotNull(extractor.extract("video", ContentHints()))
+                assertEquals(0, parser.calls)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun configFreeResponseNeedingCipherFallsBackToWatchConfig() =
+        runBlocking {
+            val client = jsonClient(DIRECT_RESPONSE.replace("expire=9999999999", "expire=9999999999&n=source"))
+            val parser = CountingParser()
+            try {
+                val extractor = makeExtractor(client, InnerTube(client, retryDelay = {}), parser, cipherService = NTransformCipherService)
+                val stream = assertNotNull(extractor.extract("video", ContentHints()))
+                assertTrue(stream.audioUrl.contains("n=solved"))
+                assertEquals(1, parser.calls)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
     fun configFetchIsSharedAndSessionChangeInvalidatesIt() =
         runBlocking {
             val client = jsonClient(DIRECT_RESPONSE)
@@ -111,6 +140,71 @@ class InnerTubeExtractorTest {
             assertNotNull(extractor.extract("three", ContentHints(isExplicit = true)))
             assertEquals(2, parser.calls)
             client.close()
+        }
+
+    @Test
+    fun unusableCachedConfigIsRefreshedBeforeRetry() =
+        runBlocking {
+            var requests = 0
+            val client =
+                HttpClient(
+                    MockEngine {
+                        requests++
+                        respond(
+                            if (requests == 2) UNPLAYABLE_RESPONSE else DIRECT_RESPONSE,
+                            HttpStatusCode.OK,
+                            headersOf("Content-Type", "application/json"),
+                        )
+                    },
+                ) {
+                    install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+                }
+            val parser = CountingParser()
+            val extractor = makeExtractor(client, InnerTube(client, retryDelay = {}), parser)
+            try {
+                assertNotNull(extractor.extract("one", ContentHints(isExplicit = true)))
+                assertNotNull(extractor.extract("two", ContentHints(isExplicit = true)))
+                assertEquals(2, parser.calls)
+                assertEquals(3, requests)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun directPlaybackDoesNotStartAnUnusedTokenRuntime() =
+        runBlocking {
+            val client = jsonClient(DIRECT_RESPONSE)
+            val innerTube = InnerTube(client, retryDelay = {}).also { it.visitorData = "visitor" }
+            var tokenCalls = 0
+            val tokenProvider =
+                object : TokenProvider {
+                    override val capabilities = TokenProviderCapabilities(providers = setOf(PoTokenProviderKind.WEB_BOTGUARD))
+
+                    override suspend fun getPoToken(
+                        videoId: String,
+                        visitorData: String,
+                        cookie: String?,
+                    ): PoTokenResult? {
+                        tokenCalls++
+                        return null
+                    }
+                }
+            val parser = CountingParser()
+            val extractor =
+                InnerTubeExtractor(
+                    parser,
+                    PlayerClientDirector(innerTube, DirectFallback, tokenProvider),
+                    AudioOnlyCipherService,
+                    innerTube,
+                    tokenProvider,
+                )
+            try {
+                assertNotNull(withTimeout(1_000) { extractor.extract("video", ContentHints(isExplicit = true)) })
+                assertEquals(0, tokenCalls)
+            } finally {
+                client.close()
+            }
         }
 
     @Test
@@ -131,9 +225,9 @@ class InnerTubeExtractorTest {
                 }
             val extractor = makeExtractor(client, innerTube, parser)
 
-            assertNotNull(extractor.extract("normal-one", ContentHints()))
+            assertNotNull(extractor.extract("normal-one", ContentHints(playbackClientOverrideId = "VISIONOS_0_1")))
             assertNotNull(extractor.extract("explicit-one", ContentHints(isExplicit = true)))
-            assertNotNull(extractor.extract("normal-two", ContentHints()))
+            assertNotNull(extractor.extract("normal-two", ContentHints(playbackClientOverrideId = "VISIONOS_0_1")))
             assertNotNull(extractor.extract("explicit-two", ContentHints(isExplicit = true)))
 
             assertEquals(listOf(false, true), modes)
@@ -365,20 +459,18 @@ class InnerTubeExtractorTest {
         }
 
     @Test
-    fun explicitTokenMintStartsWhilePlayerConfigLoads() =
+    fun requiredClientMintsTokenOnlyAfterConfigIsReady() =
         runBlocking {
             val client = jsonClient(DIRECT_RESPONSE)
             val innerTube = InnerTube(client, retryDelay = {}).also { it.visitorData = "visitor" }
-            val configStarted = CompletableDeferred<Unit>()
-            val tokenStarted = CompletableDeferred<Unit>()
+            var configReady = false
             val parser =
                 object : YtConfigParser {
                     override suspend fun fetchConfig(
                         videoId: String,
                         useLoginCookies: Boolean,
                     ): PlayerConfig {
-                        configStarted.complete(Unit)
-                        tokenStarted.await()
+                        configReady = true
                         return PlayerConfig("https://www.youtube.com/s/player/test/base.js", 123, null, null)
                     }
                 }
@@ -394,8 +486,7 @@ class InnerTubeExtractorTest {
                         cookie: String?,
                     ): PoTokenResult {
                         tokenCalls++
-                        configStarted.await()
-                        tokenStarted.complete(Unit)
+                        assertTrue(configReady)
                         return PoTokenResult("player-token", "AQID", visitorData)
                     }
                 }

--- a/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
@@ -163,6 +163,53 @@ class InnerTubeExtractorTest {
         }
 
     @Test
+    fun readyProgressiveVideoSurvivesUnresolvedAdaptiveNParameter() =
+        runBlocking {
+            val response =
+                PROGRESSIVE_AND_ADAPTIVE_VIDEO_RESPONSE.replace(
+                    "stream=adaptive",
+                    "stream=adaptive&n=source",
+                )
+            val client = jsonClient(response)
+            val cipher = RecordingCipherService()
+            val stream =
+                makeExtractor(
+                    client = client,
+                    innerTube = InnerTube(client, retryDelay = {}),
+                    parser = CountingParser(),
+                    cipherService = cipher,
+                ).extract("video", ContentHints(isExplicit = true, wantVideo = true))
+
+            assertNotNull(stream)
+            assertEquals(22, stream.videoItag)
+            assertTrue(cipher.calls.isEmpty())
+            client.close()
+        }
+
+    @Test
+    fun progressiveVideoRemainsFallbackWhenAdaptiveTransformFails() =
+        runBlocking {
+            val response =
+                PROGRESSIVE_AND_ADAPTIVE_VIDEO_RESPONSE
+                    .replace("stream=audio", "stream=audio&n=source")
+                    .replace("stream=adaptive", "stream=adaptive&n=source")
+            val client = jsonClient(response)
+            val cipher = RejectingVideoNTransformCipherService()
+            val stream =
+                makeExtractor(
+                    client = client,
+                    innerTube = InnerTube(client, retryDelay = {}),
+                    parser = CountingParser(),
+                    cipherService = cipher,
+                ).extract("video", ContentHints(isExplicit = true, wantVideo = true))
+
+            assertNotNull(stream)
+            assertEquals(22, stream.videoItag)
+            assertEquals(listOf(251, 136, 22), cipher.itags)
+            client.close()
+        }
+
+    @Test
     fun progressiveVideoRemainsFallbackWhenAdaptiveVideoIsMissing() =
         runBlocking {
             val client = jsonClient(PROGRESSIVE_VIDEO_FALLBACK_RESPONSE)
@@ -919,6 +966,30 @@ class InnerTubeExtractorTest {
             formats: List<PlayerResponse.StreamingData.Format>,
         ): List<PlayerResponse.StreamingData.Format> =
             formats.map { format -> format.copy(url = format.url?.replace("n=source", "n=solved")) }
+    }
+
+    private class RejectingVideoNTransformCipherService : ExtractionCipherService {
+        var itags = emptyList<Int>()
+
+        override suspend fun initialize() {}
+
+        override suspend fun preloadPlayerCode(playerUrl: String) {}
+
+        override suspend fun prewarmEjs() {}
+
+        override suspend fun processFormats(
+            playerUrl: String,
+            formats: List<PlayerResponse.StreamingData.Format>,
+        ): List<PlayerResponse.StreamingData.Format> {
+            itags = formats.map { it.itag }
+            return formats.map { format ->
+                when {
+                    format.isAudio -> format.copy(url = format.url?.replace("n=source", "n=solved"))
+                    format.url?.contains("n=source") == true -> format.copy(url = null)
+                    else -> format
+                }
+            }
+        }
     }
 
     private object AudioOnlyCipherService : ExtractionCipherService {

--- a/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/extraction/InnerTubeExtractorTest.kt
@@ -19,6 +19,7 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -172,7 +173,86 @@ class InnerTubeExtractorTest {
         }
 
     @Test
-    fun directPlaybackDoesNotStartAnUnusedTokenRuntime() =
+    fun refreshedConfigRetainsBudgetAfterNativeAndCachedFailures() =
+        runBlocking {
+            val parser = CountingParser()
+            var requests = 0
+            val client =
+                HttpClient(
+                    MockEngine {
+                        requests++
+                        respond(
+                            if (requests == 1 || parser.calls >= 2) DIRECT_RESPONSE else UNPLAYABLE_RESPONSE,
+                            HttpStatusCode.OK,
+                            headersOf("Content-Type", "application/json"),
+                        )
+                    },
+                ) { install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
+            val fallback =
+                object : com.metrolist.innertubex.extraction.strategy.ClientFallbackStrategy {
+                    override fun resolveClients(hints: ContentHints) =
+                        List(PlaybackClientCatalog.automaticManifests.size * 2) { YouTubeClient.VISIONOS }
+                }
+            try {
+                val extractor = makeExtractor(client, InnerTube(client, retryDelay = {}), parser, fallback)
+                assertNotNull(extractor.extract("prime", ContentHints(isExplicit = true)))
+                assertNotNull(extractor.extract("refresh", ContentHints()))
+                assertEquals(2, parser.calls)
+                assertTrue(requests > PlaybackClientCatalog.automaticManifests.size * 2 + 2)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun explicitTokenMintingRunsConcurrentlyWithConfigFetch() =
+        runBlocking {
+            val started = CompletableDeferred<Unit>()
+            val client = jsonClient(DIRECT_RESPONSE)
+            val innerTube = InnerTube(client, retryDelay = {}).also { it.visitorData = "visitor" }
+            var tokenCalls = 0
+            val provider =
+                object : TokenProvider {
+                    override val capabilities = TokenProviderCapabilities(providers = setOf(PoTokenProviderKind.WEB_BOTGUARD))
+
+                    override suspend fun getPoToken(
+                        videoId: String,
+                        visitorData: String,
+                        cookie: String?,
+                    ): PoTokenResult {
+                        tokenCalls++
+                        started.complete(Unit)
+                        return PoTokenResult("player-token", "AQID", visitorData)
+                    }
+                }
+            val parser =
+                object : YtConfigParser {
+                    override suspend fun fetchConfig(
+                        videoId: String,
+                        useLoginCookies: Boolean,
+                    ): PlayerConfig {
+                        started.await()
+                        return PlayerConfig("https://www.youtube.com/s/player/test/base.js", 123, "visitor", null)
+                    }
+                }
+            try {
+                val extractor =
+                    InnerTubeExtractor(
+                        parser,
+                        PlayerClientDirector(innerTube, WebRemixFallback, provider),
+                        AudioOnlyCipherService,
+                        innerTube,
+                        provider,
+                    )
+                assertNotNull(withTimeout(1_000) { extractor.extract("video", ContentHints(isExplicit = true)) })
+                assertEquals(1, tokenCalls)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun directPlaybackCancelsUnusedTokenPrefetch() =
         runBlocking {
             val client = jsonClient(DIRECT_RESPONSE)
             val innerTube = InnerTube(client, retryDelay = {}).also { it.visitorData = "visitor" }
@@ -187,7 +267,7 @@ class InnerTubeExtractorTest {
                         cookie: String?,
                     ): PoTokenResult? {
                         tokenCalls++
-                        return null
+                        awaitCancellation()
                     }
                 }
             val parser = CountingParser()
@@ -201,7 +281,7 @@ class InnerTubeExtractorTest {
                 )
             try {
                 assertNotNull(withTimeout(1_000) { extractor.extract("video", ContentHints(isExplicit = true)) })
-                assertEquals(0, tokenCalls)
+                assertEquals(1, tokenCalls)
             } finally {
                 client.close()
             }

--- a/src/commonTest/kotlin/com/metrolist/innertubex/extraction/VideoFormatSelectorTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/extraction/VideoFormatSelectorTest.kt
@@ -44,7 +44,7 @@ class VideoFormatSelectorTest {
     }
 
     @Test
-    fun prefersWebmAndBitrateAtEqualHeight() {
+    fun prefersLowerBitrateNativeVideoAtEqualHeight() {
         val equal =
             listOf(
                 Format(
@@ -79,6 +79,16 @@ class VideoFormatSelectorTest {
                     ),
             )?.itag,
         )
+    }
+
+    @Test
+    fun expensiveVp9DoesNotDisplaceCheaperAvcAtTheSameResolution() {
+        val avc = formats.first().copy(bitrate = 2_474_373)
+        val vp9 = formats[1].copy(width = 1280, height = 720, bitrate = 7_281_188)
+        val av1 = avc.copy(itag = 398, mimeType = "video/mp4; codecs=\"av01\"", bitrate = 1_000_000)
+        assertEquals(avc.itag, selectBestVideoFormat(listOf(vp9, avc, av1))?.itag)
+        assertEquals(vp9.itag, selectBestVideoFormat(listOf(avc, vp9.copy(bitrate = 1_000_000)))?.itag)
+        assertEquals(vp9.itag, selectBestVideoFormat(listOf(avc.copy(bitrate = 0), vp9))?.itag)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/metrolist/innertubex/extraction/YtConfigParserTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/extraction/YtConfigParserTest.kt
@@ -26,6 +26,8 @@ class YtConfigParserTest {
         )
         assertEquals("abc123", parser.extractPlayerId("https:\\/\\/www.youtube.com\\/s\\/player\\/abc123\\/www-widgetapi.js"))
         assertEquals(20668, parser.extractSignatureTimestamp("signatureTimestamp:20668"))
+        assertEquals(20668, parser.extractSignatureTimestamp("{\"signatureTimestamp\":20668}"))
+        assertEquals(20668, parser.extractSignatureTimestamp("{\"sts\":20668}"))
         assertNull(parser.extractPlayerUrl("{\"PLAYER_JS_URL\":\"https://evil.test/s/player/x/base.js\"}"))
         assertNull(parser.extractPlayerUrl("{\"PLAYER_JS_URL\":\"https://www.youtube.com/watch?v=x\"}"))
         assertNull(parser.extractPlayerUrl("{\"PLAYER_JS_URL\":\"https://user:pass@www.youtube.com/s/player/x/base.js\"}"))

--- a/src/commonTest/kotlin/com/metrolist/innertubex/extraction/strategy/PlaybackClientStrategyTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/extraction/strategy/PlaybackClientStrategyTest.kt
@@ -160,7 +160,7 @@ class PlaybackClientStrategyTest {
     }
 
     @Test
-    fun automaticCandidatesKeepDirectClientsBeforeSabrByDefault() {
+    fun automaticCandidatesKeepSabrBehindAllDirectClients() {
         val candidates =
             ContentAwareFallbackStrategy()
                 .selectClients(
@@ -176,6 +176,55 @@ class PlaybackClientStrategyTest {
         assertTrue(firstSabr > 0)
         assertTrue(candidates.take(firstSabr).none { it.client.useSabr })
         assertTrue(candidates.drop(firstSabr).all { it.client.useSabr })
+    }
+
+    @Test
+    fun kidsPlaybackTriesUntokenizedDirectClientBeforeTokenMinting() {
+        val candidates =
+            ContentAwareFallbackStrategy()
+                .selectClients(
+                    ClientSelectionRequest(
+                        hints = ContentHints(isKidsContent = true),
+                        authenticated = true,
+                        availablePoTokenProviders = allProviders,
+                        webViewAvailable = true,
+                    ),
+                ).candidates
+        assertEquals("WEB_KIDS", candidates.first().manifest?.id)
+    }
+
+    @Test
+    fun explicitPlaybackKeepsProvenDirectClientFirst() {
+        val candidates =
+            ContentAwareFallbackStrategy()
+                .selectClients(
+                    ClientSelectionRequest(
+                        hints = ContentHints(isExplicit = true),
+                        authenticated = true,
+                        availablePoTokenProviders = allProviders,
+                        webViewAvailable = true,
+                    ),
+                ).candidates
+        assertEquals("WEB_REMIX", candidates.first().manifest?.id)
+    }
+
+    @Test
+    fun configFreeFastPathExcludesWatchPageDependentClients() {
+        val candidates =
+            ContentAwareFallbackStrategy()
+                .selectClients(
+                    ClientSelectionRequest(
+                        hints = ContentHints(),
+                        authenticated = true,
+                        availablePoTokenProviders = allProviders,
+                        webViewAvailable = true,
+                        fastPathOnly = true,
+                        javaScriptRuntimeAvailable = false,
+                    ),
+                ).candidates
+        assertTrue(candidates.isNotEmpty())
+        assertTrue(candidates.all { it.manifest?.request?.signatureTimestamp == false })
+        assertTrue(candidates.none { it.client.useWebPoTokens })
     }
 
     @Test

--- a/src/commonTest/kotlin/com/metrolist/innertubex/sabr/SabrAudioStreamTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/sabr/SabrAudioStreamTest.kt
@@ -272,6 +272,69 @@ class SabrAudioStreamTest {
         }
 
     @Test
+    fun multiSegmentResponsePreservesBufferedRangeDiagnostics() =
+        runBlocking {
+            val diagnostics = mutableListOf<SabrResponseDiagnostics>()
+            val engine =
+                MockEngine {
+                    respond(
+                        content = initializationAndSegmentResponse(endSegmentNumber = 1) + finalSegmentResponse(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/vnd.yt-ump"),
+                    )
+                }
+
+            val chunks =
+                SabrAudioStream(
+                    httpClient = HttpClient(engine),
+                    bootstrap = bootstrap().copy(durationMs = 2_000, contentLengthBytes = 10),
+                    onResponse = diagnostics::add,
+                ).chunks().toList()
+
+            assertEquals(3, chunks.size)
+            assertEquals(6, diagnostics.single().selectedMediaBytes)
+            assertEquals(2, diagnostics.single().selectedSegmentCount)
+            assertEquals(SabrBufferedRange(SabrFormatId(140, 100, "x"), 0, 2_000, 0, 1), diagnostics.single().bufferedRanges.single())
+        }
+
+    @Test
+    fun duplicateOldAndOutOfOrderNewSegmentsRemainOrdered() =
+        runBlocking {
+            var requests = 0
+            val engine =
+                MockEngine {
+                    requests++
+                    respond(
+                        content =
+                            if (requests == 1) {
+                                initializationAndSegmentResponse(endSegmentNumber = 2, durationMs = 3_000)
+                            } else {
+                                mediaResponseSegment(headerId = 3, sequenceNumber = 0, startMs = 0, data = byteArrayOf(5, 6, 7)) +
+                                    mediaResponseSegment(
+                                        headerId = 4,
+                                        sequenceNumber = 2,
+                                        startMs = 2_000,
+                                        data = byteArrayOf(11, 12, 13),
+                                    ) +
+                                    mediaResponseSegment(headerId = 5, sequenceNumber = 1, startMs = 1_000, data = byteArrayOf(8, 9, 10)) +
+                                    umpPart(UmpPartType.END_OF_TRACK, byteArrayOf())
+                            },
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/vnd.yt-ump"),
+                    )
+                }
+
+            val chunks =
+                SabrAudioStream(
+                    httpClient = HttpClient(engine),
+                    bootstrap = bootstrap().copy(durationMs = 3_000, contentLengthBytes = 13),
+                ).chunks().toList()
+
+            assertEquals(2, requests)
+            assertEquals(listOf(null, 0, 1, 2), chunks.map(SabrChunk::sequenceNumber))
+        }
+
+    @Test
     fun finalSegmentCompletesWithoutEndOfTrackPart() =
         runBlocking {
             var requestCount = 0
@@ -591,13 +654,27 @@ class SabrAudioStreamTest {
             umpPart(UmpPartType.MEDIA_END, byteArrayOf(2))
 
     private fun finalSegmentResponse(includeEndOfTrack: Boolean = true): ByteArray =
+        mediaResponseSegment(headerId = 3, sequenceNumber = 1, startMs = 1_000, data = byteArrayOf(8, 9, 10)) +
+            if (includeEndOfTrack) umpPart(UmpPartType.END_OF_TRACK, byteArrayOf()) else byteArrayOf()
+
+    private fun mediaResponseSegment(
+        headerId: Int,
+        sequenceNumber: Int,
+        startMs: Long,
+        data: ByteArray,
+    ): ByteArray =
         umpPart(
             UmpPartType.MEDIA_HEADER,
-            mediaHeader(headerId = 3, isInit = false, sequenceNumber = 1, contentLength = 3, startMs = 1_000),
+            mediaHeader(
+                headerId = headerId,
+                isInit = false,
+                sequenceNumber = sequenceNumber,
+                contentLength = data.size,
+                startMs = startMs,
+            ),
         ) +
-            umpPart(UmpPartType.MEDIA, byteArrayOf(3, 8, 9, 10)) +
-            umpPart(UmpPartType.MEDIA_END, byteArrayOf(3)) +
-            if (includeEndOfTrack) umpPart(UmpPartType.END_OF_TRACK, byteArrayOf()) else byteArrayOf()
+            umpPart(UmpPartType.MEDIA, byteArrayOf(headerId.toByte()) + data) +
+            umpPart(UmpPartType.MEDIA_END, byteArrayOf(headerId.toByte()))
 
     private fun seekResponse(
         sequenceNumber: Int,

--- a/src/commonTest/kotlin/com/metrolist/innertubex/sabr/SabrAudioStreamTest.kt
+++ b/src/commonTest/kotlin/com/metrolist/innertubex/sabr/SabrAudioStreamTest.kt
@@ -335,6 +335,45 @@ class SabrAudioStreamTest {
         }
 
     @Test
+    fun rejectsUnseenSequenceBelowEmittedRange() =
+        runBlocking {
+            var requests = 0
+            val engine =
+                MockEngine {
+                    requests++
+                    respond(
+                        content =
+                            if (requests == 1) {
+                                initializationResponsePrefix(endSegmentNumber = 2, durationMs = 3_000) +
+                                    mediaResponseSegment(headerId = 2, sequenceNumber = 1, startMs = 1_000, data = byteArrayOf(8, 9, 10))
+                            } else {
+                                mediaResponseSegment(headerId = 3, sequenceNumber = 0, startMs = 0, data = byteArrayOf(5, 6, 7)) +
+                                    mediaResponseSegment(
+                                        headerId = 4,
+                                        sequenceNumber = 2,
+                                        startMs = 2_000,
+                                        data = byteArrayOf(11, 12, 13),
+                                    ) +
+                                    umpPart(UmpPartType.END_OF_TRACK, byteArrayOf())
+                            },
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/vnd.yt-ump"),
+                    )
+                }
+
+            val error =
+                assertFailsWith<SabrProtocolException> {
+                    SabrAudioStream(
+                        httpClient = HttpClient(engine),
+                        bootstrap = bootstrap().copy(durationMs = 3_000, contentLengthBytes = null),
+                    ).bytes().toList()
+                }
+
+            assertEquals("SABR segment sequence gap: expected 3, received 0", error.message)
+            assertEquals(2, requests)
+        }
+
+    @Test
     fun finalSegmentCompletesWithoutEndOfTrackPart() =
         runBlocking {
             var requestCount = 0
@@ -627,8 +666,11 @@ class SabrAudioStreamTest {
 
     private fun completeResponse(endSegmentNumber: Int): ByteArray = initializationResponsePrefix(endSegmentNumber) + mediaResponseSuffix()
 
-    private fun initializationResponsePrefix(endSegmentNumber: Int): ByteArray =
-        umpPart(UmpPartType.FORMAT_INITIALIZATION_METADATA, initialization(endSegmentNumber)) +
+    private fun initializationResponsePrefix(
+        endSegmentNumber: Int,
+        durationMs: Long = 1_000,
+    ): ByteArray =
+        umpPart(UmpPartType.FORMAT_INITIALIZATION_METADATA, initialization(endSegmentNumber, durationMs = durationMs)) +
             umpPart(UmpPartType.MEDIA_HEADER, mediaHeader(headerId = 1, isInit = true, sequenceNumber = 0, contentLength = 4)) +
             umpPart(UmpPartType.MEDIA, byteArrayOf(1, 1, 2, 3, 4)) +
             umpPart(UmpPartType.MEDIA_END, byteArrayOf(1))

--- a/src/desktopTest/kotlin/com/metrolist/innertubex/cipher/EjsChallengeSolverTest.kt
+++ b/src/desktopTest/kotlin/com/metrolist/innertubex/cipher/EjsChallengeSolverTest.kt
@@ -1,11 +1,118 @@
 package com.metrolist.innertubex.cipher
 
 import com.metrolist.innertubex.InnerTubeLogger
+import com.metrolist.innertubex.utils.sha1
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class EjsChallengeSolverTest {
+    @Test
+    fun persistsAndRestoresPreprocessedPlayerAcrossSolvers() =
+        runBlocking {
+            val stored = mutableMapOf<String, String>()
+            var reads = 0
+            val read: suspend (String) -> String? = { key ->
+                reads += 1
+                stored[key]
+            }
+            val write: suspend (String, String?) -> Unit = { key, value ->
+                if (value == null) stored.remove(key) else stored[key] = value
+            }
+
+            val firstEngine = QuickJsEngine()
+            try {
+                val firstSolver = EjsChallengeSolver(firstEngine, InnerTubeLogger.NONE)
+                firstSolver.setPreprocessedPlayerCache(read, write)
+                val challenge = "private_challenge_not_for_persistent_storage"
+                val first = firstSolver.solve(PLAYER_URL, PLAYER_CODE, listOf("sig" to listOf(challenge)))
+                val memoryHit = firstSolver.solve(PLAYER_URL, "", listOf("n" to listOf("value")))
+
+                assertEquals(challenge.reversed(), first.sigByChallenge[challenge])
+                assertNotNull(first.preprocessedPlayer)
+                assertFalse(stored.values.single().contains(challenge))
+                assertFalse(stored.values.single().contains(challenge.reversed()))
+                assertEquals("value_done", memoryHit.nByChallenge["value"])
+                assertEquals(1, reads)
+            } finally {
+                firstEngine.dispose()
+            }
+
+            val secondEngine = QuickJsEngine()
+            try {
+                val secondSolver = EjsChallengeSolver(secondEngine, InnerTubeLogger.NONE)
+                secondSolver.setPreprocessedPlayerCache(read, write)
+                val restored = secondSolver.solve(PLAYER_URL, "", listOf("n" to listOf("fresh")))
+
+                assertEquals("fresh_done", restored.nByChallenge["fresh"])
+                assertEquals(2, reads)
+                assertTrue(stored.keys.single().matches(Regex("[a-f0-9]{40}")))
+            } finally {
+                secondEngine.dispose()
+            }
+        }
+
+    @Test
+    fun cacheKeysIsolatePlayerAndSolverVersions() {
+        val bundleA = sha1("solver-a")
+        val bundleB = sha1("solver-b")
+        val key = assertNotNull(preprocessedPlayerCacheKey(PLAYER_URL, bundleA))
+
+        assertTrue(key.matches(Regex("[a-f0-9]{40}")))
+        assertFalse(key.contains("youtube"))
+        assertNotEquals(key, preprocessedPlayerCacheKey(OTHER_PLAYER_URL, bundleA))
+        assertNotEquals(key, preprocessedPlayerCacheKey(PLAYER_URL, bundleB))
+        assertNull(preprocessedPlayerCacheKey("https://example.com/player.js", bundleA))
+    }
+
+    @Test
+    fun badStoredPlayersAreDeletedBeforeFullPlayerFallback() =
+        runBlocking {
+            for (badValue in listOf("not javascript", "x".repeat(8 * 1024 * 1024 + 1))) {
+                val engine = QuickJsEngine()
+                val writes = mutableListOf<String?>()
+                try {
+                    val solver = EjsChallengeSolver(engine, InnerTubeLogger.NONE)
+                    solver.setPreprocessedPlayerCache(
+                        read = { badValue },
+                        write = { _, value -> writes += value },
+                    )
+
+                    val result = solver.solve(PLAYER_URL, PLAYER_CODE, listOf("sig" to listOf("abc")))
+
+                    assertEquals("cba", result.sigByChallenge["abc"])
+                    assertNull(writes.first())
+                    assertNotNull(writes.last())
+                } finally {
+                    engine.dispose()
+                }
+            }
+        }
+
+    @Test
+    fun cacheCallbackFailuresDoNotBreakFullPlayerSolving() =
+        runBlocking {
+            val engine = QuickJsEngine()
+            try {
+                val solver = EjsChallengeSolver(engine, InnerTubeLogger.NONE)
+                solver.setPreprocessedPlayerCache(
+                    read = { error("read failed") },
+                    write = { _, _ -> error("write failed") },
+                )
+
+                val result = solver.solve(PLAYER_URL, PLAYER_CODE, listOf("sig" to listOf("abc")))
+
+                assertEquals("cba", result.sigByChallenge["abc"])
+            } finally {
+                engine.dispose()
+            }
+        }
+
     @Test
     fun oversizedChallengesAreRejectedBeforeInitializingQuickJs() =
         runBlocking {
@@ -22,4 +129,29 @@ class EjsChallengeSolverTest {
             assertTrue(result.nByChallenge.isEmpty())
             assertTrue(result.preprocessedPlayer == null)
         }
+
+    private companion object {
+        const val PLAYER_URL = "https://www.youtube.com/s/player/12345678/player.js"
+        const val OTHER_PLAYER_URL = "https://www.youtube.com/s/player/87654321/player.js"
+        val PLAYER_CODE =
+            """
+            (function() {
+              function PlayerUrl(url, key, signature) {
+                this.values = {s: signature || null, n: null};
+              }
+              PlayerUrl.prototype.set = function(key, value) { this.values[key] = value; };
+              PlayerUrl.prototype.get = function(key) { return this.values[key]; };
+              PlayerUrl.prototype.clone = function() { return this; };
+              PlayerUrl.prototype.apply = function() {
+                if (this.values.s) this.values.s = this.values.s.split("").reverse().join("");
+                if (this.values.n) this.values.n += "_done";
+              };
+              function transform(url, key, signature) {
+                var value = new PlayerUrl(url, key, signature);
+                value.set("alr", "yes");
+                return value;
+              }
+            }).call(this);
+            """.trimIndent()
+    }
 }


### PR DESCRIPTION
## Summary

Reduce work on the playback critical path without trading away sustained playback:

- Try config-free native audio before fetching a watch page, player JavaScript, or tokens. Keep explicit, age-restricted, uploaded, live, video, and manually overridden requests on their existing paths.
- Keep explicit token minting concurrent with configuration loading, but cancel any unused prefetch before returning a result.
- Recognize quoted `STS` / `signatureTimestamp` keys in watch configuration, avoiding an unnecessary player-script download.
- Retry a failed cached configuration with fresh configuration instead of repeatedly using the same stale data.
- Prefer `WEB_KIDS` for known made-for-kids tracks. Preserve the proven explicit-client ordering and keep SABR behind all direct clients.


## Follow-up: lower cipher, format-selection, and SABR overhead (`4714672`)

- Persist generated EJS preprocessed players behind an optional callback API. Cache keys combine the validated player-script URL with the EJS bundle SHA-1; entries are size-limited, atomically replaced, bounded to four players, and invalid entries fall back to full preprocessing.
- Process the selected audio and video formats in one cipher invocation instead of two serial QuickJS evaluations. Cached solves are verified against every requested challenge before use, and QuickJS garbage collection runs after full-player preprocessing.
- Prefer adaptive video at the requested resolution, use progressive video only for resolutions absent from adaptive data, and rank equal-resolution native formats by bitrate so a much larger VP9 stream does not displace a cheaper AVC stream.
- Remove the per-stream emitted-sequence set and temporary segment list from SABR processing. A first/last contiguous emitted range ignores only known duplicates; unseen lower sequences remain pending so gap validation rejects incomplete streams. Scalar counters retain diagnostics while reducing allocation pressure.
- Retain a same-height progressive video candidate until the preferred adaptive URL is validated. A ready progressive URL stays on the direct path when adaptive `n` transformation is needed, and remains the bounded fallback if that transformation fails.

The only new public surface is the optional `YouTubeCipherService.setPreprocessedPlayerCache` callback pair; authentication, token validation, client ordering, and manual overrides are unchanged.

### Measured follow-up

On the connected-device cipher benchmark, a cold EJS solve took 3,934 ms and a fresh solver restored the preprocessed player from disk in 1,156 ms. This is a single backend measurement; first use of a new player still pays preprocessing cost.

## Comprehensive review

Reviewed the changed extraction/parser/selection paths and their callers, including authentication transitions, configuration reuse, client overrides, request budgets, cancellation, and application integration.

Findings addressed:

1. **Critical-path waste:** an unused token prefetch could hold extraction open for up to 18 seconds. Cancel it in `finally`, preserving concurrency when explicit playback actually needs it.
2. **Unnecessary requests:** eligible native audio does not require watch configuration. The fast-path eligibility check now explicitly excludes watch-dependent and token-required clients.
3. **Stale recovery:** failed cached configuration is invalidated by identity and refreshed. Concurrent refreshes share the existing fetch mutex; a stale caller cannot evict another caller's replacement.
4. **Authentication race:** fetched configuration is not cached if the session changed during the fetch, including prewarming.
5. **Parser miss:** quoted timestamp keys previously caused an avoidable base.js request.
6. **Rejected optimization:** moving untokenized SABR ahead of attested direct playback gave misleadingly quick first packets but failed a 30-second decoding check after roughly 20 seconds with a server attestation request. That ordering is not included.
7. **Rejected regression:** globally prioritizing untokenized direct clients added an unnecessary request for explicit tracks. Selection is now targeted to known kids content, with an explicit-order regression check.

8. **Codex follow-up:** increased the finite request budget from `2 × automatic clients + 2` to `4 × automatic clients + 2`, allowing cached and fresh configuration passes plus native probes. A regression exhausts the native/cached batches and verifies that fresh configuration is still tried. This intentionally permits more requests on failing paths; successful native playback still uses one.
9. **Format-fallback follow-up:** adaptive video suppresses its progressive peer only after its URL is playback-ready. Direct and ciphered regressions cover unresolved adaptive `n` parameters while preserving the requested resolution.

Apart from the optional `YouTubeCipherService.setPreprocessedPlayerCache` callback pair described above, there are no API, authentication, token-validation, client-ordering, or manual-override changes.

## Verification

- `allTests`: **215 desktop tests and 195 Android-host tests passed**; `ktlintCheck`, `apiCheck`, assembly, and local Maven publication passed.
- Added regression coverage for persistent cache restore/invalidation, adaptive/progressive selection, combined cipher processing, native bitrate choice, SABR diagnostic counters and sequence gaps, plus progressive fallback before and after failed adaptive transformation.
- Added checks for config-free extraction, fallback to configuration, stale-cache refresh/coalescing, session changes, quoted timestamps, explicit ordering, and kids ordering.
- Application integration measures resolution, first media, cache hits, and 30 seconds of decoded audio for normal, explicit, and kids tracks. Final measurements are documented in the companion Metrolist-KMP PR.

Companion application: https://github.com/MetrolistGroup/Metrolist-KMP/pull/127. This PR is merged as `13f8e4d36d249024cfe356c9cd67cd7fd8ee6493`; the companion application pins alias `13f8e4d36d` and is merged into `main` as `99e2c08fb09770c384d61d5a13bfec0887aa1f1f`.

Local integration must use the application coordinates:

```sh
./gradlew -PGROUP=com.github.MetrolistGroup.innertubex \
  -PVERSION_NAME=13f8e4d36d publishToMavenLocal
```

The supplied cookie/token was used only for live checks. Credentials and signed media URLs are not included in this PR.



## Follow-up verification details

The companion application passed shared Android-host/desktop tests, Android assembly, and the desktop build locally against the permanent merged `main` commit; all GitHub checks passed before its merge. The supplied capture and cookie/token were used only for local diagnosis; no credentials or signed media URLs are included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent caching for preprocessed player scripts.
  - Added a faster path for eligible audio-only playback.
  - Added improved playback configuration refresh and token cleanup.

- **Improvements**
  - Improved video format selection across resolution, codec, and bitrate.
  - Improved playback client selection for kids and explicit content.
  - Improved cipher processing and playback fallback behavior.
  - Improved SABR handling for duplicate, out-of-order, and multi-segment responses.
  - Expanded compatibility with additional player configuration formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






